### PR TITLE
remove namespaces

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -2,7 +2,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: valheim-server
-  namespace: default
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
i prefer for the chart to use the helm-specified namespace, or your default context