### PR TITLE
adding nodeSelector to the chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ helm install valheim-server valheim-k8s/valheim-k8s  \
 | `storage.kind`                             | Storage strategy/soln used to provide the game-server with persistence | `hostvol`             |
 | `storage.hostvol.path`                     | The folder to be mounted into /config in the game-server pod | `/data/valheim`                 |
 | `networking.serviceType`                   | The type of service e.g `NodePort`, `LoadBalancer` or `ClusterIP` | `LoadBalancer`                 |
+| `nodeSelector`                   |  | `{}`                 |
 
 ## Persistence
 

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -11,6 +11,10 @@ spec:
       labels:
         app: valheim-server
     spec:
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - image: lloesche/valheim-server:latest
         name: vailheim-server

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -11,3 +11,5 @@ storage:
 
 networking:
   serviceType: LoadBalancer
+
+nodeSelector: {}


### PR DESCRIPTION
As mentioned in [this issue](https://github.com/Addyvan/valheim-k8s/issues/14) it would be handy to have `nodeSelector` added to the chart, especially because this is using hostvol and scheduling to another node would create a new world. 