### PR TITLE
Implement PVC storage support

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ adminlist.txt  backups  bannedlist.txt  permittedlist.txt  prefs  worlds
 
 To use a `persistentVolumeClaim` for storage, you will need to first set up your CSI and StorageClass for your K8s cluster. Information regarding that differs by cloud provider and there are several guides available for configuring each of them.
 
-Once you have your StorageClass set up, set `storage.kind` to `persistentVolumeClaim`, set `storage.pvc.storageClassName` to the name of your previously configured StorageClass, and optionally set `storage.pvc.size` to the size of the volume to create.
+Once you have your StorageClass set up, set `storage.kind` to `persistentVolumeClaim`, optionally set `storage.pvc.storageClassName` to the name of your previously configured StorageClass (or it will use the default StorageClass), and set `storage.pvc.size` to the size of the volume to create (default 1Gi).
 
 ### Using an existing world
 

--- a/README.md
+++ b/README.md
@@ -19,19 +19,21 @@ helm install valheim-server valheim-k8s/valheim-k8s  \
 
 ## Configuration
 
-| Parameter                                  | Description                                                | Default                           |
-|:-------------------------------------------|:-----------------------------------------------------------|:----------------------------------|
-| `worldName`                                | Prefix of the world files to use (will make new if missing)| `example-world-name`              |
-| `serverName`                               | Server name displayed in the server browser(s)             | `example-server-name`             |
-| `password`                                 | Server password                                            | `password`                        |
-| `storage.kind`                             | Storage strategy/soln used to provide the game-server with persistence | `hostvol`             |
-| `storage.hostvol.path`                     | The folder to be mounted into /config in the game-server pod | `/data/valheim`                 |
-| `networking.serviceType`                   | The type of service e.g `NodePort`, `LoadBalancer` or `ClusterIP` | `LoadBalancer`                 |
-| `nodeSelector`                   |  | `{}`                 |
+| Parameter                                  | Description                                                            | Default                 |
+|:-------------------------------------------|:-----------------------------------------------------------------------|:------------------------|
+| `worldName`                                | Prefix of the world files to use (will make new if missing)            | `example-world-name`    |
+| `serverName`                               | Server name displayed in the server browser(s)                         | `example-server-name`   |
+| `password`                                 | Server password                                                        | `password`              |
+| `storage.kind`                             | Storage strategy/soln used to provide the game-server with persistence | `hostvol`               |
+| `storage.hostvol.path`                     | The folder to be mounted into /config in the game-server pod           | `/data/valheim`         |
+| `storage.pvc.storageClassName`             | The storageClass used to create the persistentVolumeClaim              | `default`               |
+| `storage.pvc.size`                         | The size of the persistent volume to be created                        | `1Gi`                   |
+| `networking.serviceType`                   | The type of service e.g `NodePort`, `LoadBalancer` or `ClusterIP`      | `LoadBalancer`          |
+| `nodeSelector`                             |                                                                        | `{}`                    |
 
 ## Persistence
 
-The only form of persistence currently available is through mounting a `hostvol`. Please create an issue if you would like support for specific cloud storage solutions via PVCs / storageclasses. They vary by provider so PRs / testers welcome for this. 
+Currently persistence is supported through mounting a `hostvol` or via a `persistentVolumeClaim`. Please create an issue if you would like support for specific cloud storage solutions via PVCs / storageclasses. They vary by provider so PRs / testers welcome for this. 
 
 ### Using a Host Volume
 
@@ -40,6 +42,12 @@ On the node you wish to use make sure the folder you are mounting exists (ideall
 $ ls /data/valheim
 adminlist.txt  backups  bannedlist.txt  permittedlist.txt  prefs  worlds
 ```
+
+### Using a persistentVolumeClaim
+
+To use a `persistentVolumeClaim` for storage, you will need to first set up your CSI and StorageClass for your K8s cluster. Information regarding that differs by cloud provider and there are several guides available for configuring each of them.
+
+Once you have your StorageClass set up, set `storage.kind` to `persistentVolumeClaim`, set `storage.pvc.storageClassName` to the name of your previously configured StorageClass, and optionally set `storage.pvc.size` to the size of the volume to create.
 
 ### Using an existing world
 

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -45,4 +45,9 @@ spec:
           path: {{ .Values.storage.hostvol.path }}
           type: Directory
       {{ end }}
-
+      {{ if eq .Values.storage.kind "persistentVolumeClaim" }}
+      volumes:
+      - name: gamefiles
+        persistentVolumeClaim:
+          claimName: valheim-server-world-data
+      {{ end }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -6,6 +6,8 @@ spec:
   selector:
     matchLabels:
       app: valheim-server
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:
@@ -25,6 +27,12 @@ spec:
           value: {{ .Values.worldName }}
         - name: SERVER_PASS
           value: {{ .Values.password }}
+        {{ if .Values.extraEnvironmentVars -}}
+        {{ range $key, $value := .Values.extraEnvironmentVars }}
+        - name: {{ $key }}
+          value: {{ $value | quote }}
+        {{ end -}}
+        {{ end -}}
         ports:
         - containerPort: 2456
           name: game1
@@ -32,22 +40,38 @@ spec:
           name: game2
         - containerPort: 2458
           name: game3
-        {{ if eq .Values.storage.kind "hostvol" }}
         volumeMounts:
+        {{ if .Values.storage.kind }}
         - mountPath: /config
           name: gamefiles
         {{ end }}
+        {{ range .Values.extraVolumes }}
+        - name: {{ .name }}
+          readOnly: true
+          mountPath: /extraVolumes/{{ .name }}
+        {{ end }}
         resources: {{- toYaml .Values.resources | nindent 10 }}
-      {{ if eq .Values.storage.kind "hostvol" }}
       volumes:
+      {{ if eq .Values.storage.kind "hostvol" }}
       - name: gamefiles
         hostPath:
           path: {{ .Values.storage.hostvol.path }}
           type: Directory
       {{ end }}
       {{ if eq .Values.storage.kind "persistentVolumeClaim" }}
-      volumes:
       - name: gamefiles
         persistentVolumeClaim:
           claimName: valheim-server-world-data
+      {{ end }}
+      {{ range .Values.extraVolumes }}
+      - name: {{ .name }}
+        {{ .type }}:
+          {{ if (eq .type "configMap") }}
+          name: {{ .name }}
+          {{ else if (eq .type "secret") }}
+          secretName: {{ .name }}
+          {{ if .defaultMode }}
+          defaultMode: {{ .defaultMode }}
+          {{ end }}
+          {{ end }}
       {{ end }}

--- a/chart/templates/persistentvolumeclaim.yml
+++ b/chart/templates/persistentvolumeclaim.yml
@@ -1,0 +1,13 @@
+{{ if eq .Values.storage.kind "persistentVolumeClaim" }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: valheim-server-world-data
+spec:
+  storageClassName: {{ .Values.storage.pvc.storageClassName }}
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.storage.pvc.size }}
+{{ end }}

--- a/chart/templates/persistentvolumeclaim.yml
+++ b/chart/templates/persistentvolumeclaim.yml
@@ -4,7 +4,9 @@ kind: PersistentVolumeClaim
 metadata:
   name: valheim-server-world-data
 spec:
+  {{ if .Values.storage.pvc.storageClassName }}
   storageClassName: {{ .Values.storage.pvc.storageClassName }}
+  {{ end }}
   accessModes:
     - ReadWriteOnce
   resources:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -9,7 +9,6 @@ storage:
   hostvol:
     path: /data/valheim
   pvc:
-    storageClassName: default
     size: 1Gi
 
 networking:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -15,3 +15,19 @@ networking:
   serviceType: LoadBalancer
 
 nodeSelector: {}
+
+# resources:
+#   requests:
+#     memory: "4Gi"
+#     cpu: "2000m"
+
+# extraEnvironmentVars:
+#   BACKUPS: true
+#   BACKUPS_CRON: "0 * * * *"
+#   BACKUPS_MAX_AGE: 3
+#   POST_BACKUP_HOOK: "timeout 300 scp -i /extraVolumes/backup-ssh-key/ssh-privatekey -o StrictHostKeyChecking=no @BACKUP_FILE@ myself@example.com:~/valheim_backups/$(basename @BACKUP_FILE@)"
+
+# extraVolumes:
+# - type: secret
+#   name: backup-ssh-key
+#   defaultMode: 0600

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -8,6 +8,9 @@ storage:
   kind: hostvol
   hostvol:
     path: /data/valheim
+  pvc:
+    storageClassName: default
+    size: 1Gi
 
 networking:
   serviceType: LoadBalancer


### PR DESCRIPTION
This introduces a new `storage.kind` of `persistentVolumeClaim` to enable the use of PVCs for persistent storage. It assumes you have already configured a StorageClass for your specific cloud provider.

New Parameters:
- `storage.kind` of `persistentVolumeClaim`
- `storage.pvc.storageClassName` - The storageClass used to create the persistentVolumeClaim
- `storage.pvc.size` - The size of the persistent volume to be created

Fixes #21 