### PR TITLE
MountVolume.SetUp failed for volume "gamefiles" : hostPath type check failed: /data/valheim is not a directory

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -56,6 +56,7 @@ spec:
       - name: gamefiles
         hostPath:
           path: {{ .Values.storage.hostvol.path }}
+          type: DirectoryOrCreate
       {{ end }}
       {{ if eq .Values.storage.kind "persistentVolumeClaim" }}
       - name: gamefiles

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -56,7 +56,6 @@ spec:
       - name: gamefiles
         hostPath:
           path: {{ .Values.storage.hostvol.path }}
-          type: Directory
       {{ end }}
       {{ if eq .Values.storage.kind "persistentVolumeClaim" }}
       - name: gamefiles


### PR DESCRIPTION
Hitting https://github.com/kubernetes/kubernetes/issues/90263

Solution is to change "type: Directory" to "type: DirectoryOrCreate" or remove the "type: Directory" check altogether (both commits tested in the PR).

Running via ArgoCD v2.0.0+f5119c0 on:

C:\Users\Jonathon\rancher> kubectl version
Client Version: version.Info{Major:"1", Minor:"19", GitVersion:"v1.19.0", GitCommit:"e19964183377d0ec2052d1f1fa930c4d7575bd50", GitTreeState:"clean", BuildDate:"2020-08-26T14:30:33Z", GoVersion:"go1.15", Compiler:"gc", Platform:"windows/amd64"}
Server Version: version.Info{Major:"1", Minor:"19", GitVersion:"v1.19.2", GitCommit:"f5743093fd1c663cb0cbc89748f730662345d44d", GitTreeState:"clean", BuildDate:"2020-09-16T13:32:58Z", GoVersion:"go1.15", Compiler:"gc", Platform:"linux/amd64"}