### PR TITLE
Adding configuration options for ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ helm install valheim-server valheim-k8s/valheim-k8s  \
 | `storage.pvc.storageClassName`             | The storageClass used to create the persistentVolumeClaim              | `default`               |
 | `storage.pvc.size`                         | The size of the persistent volume to be created                        | `1Gi`                   |
 | `networking.serviceType`                   | The type of service e.g `NodePort`, `LoadBalancer` or `ClusterIP`      | `LoadBalancer`          |
+| `networking.gamePort`                      | The UDP start port the server will listen on                           |  `2456`                 |
+| `networking.publishQueryPort`              | Expose the Steam query port (gamePort + 1)                             |  `true`                 |
 | `nodeSelector`                             |                                                                        | `{}`                    |
 | `image.repository` | Specifies container image repository | `lloesche/valheim-server` |
 | `image.tag` | Specifies container image tag | `latest` |

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -27,6 +27,8 @@ spec:
           value: {{ .Values.worldName }}
         - name: SERVER_PASS
           value: {{ .Values.password }}
+        - name: SERVER_PORT
+          value: {{ .Values.networking.gamePort | quote }}
         {{ if .Values.extraEnvironmentVars -}}
         {{ range $key, $value := .Values.extraEnvironmentVars }}
         - name: {{ $key }}
@@ -34,12 +36,10 @@ spec:
         {{ end -}}
         {{ end -}}
         ports:
-        - containerPort: 2456
-          name: game1
-        - containerPort: 2457
-          name: game2
-        - containerPort: 2458
-          name: game3
+        - containerPort: {{ .Values.networking.gamePort | int }}
+          name: gameport
+        - containerPort: {{ .Values.networking.gamePort | int | add 1 }}
+          name: queryport
         volumeMounts:
         {{ if .Values.storage.kind }}
         - mountPath: /config

--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -4,18 +4,16 @@ metadata:
   name: valheim-server
 spec:
   ports:
-  - name: game1
-    port: 2456
-    targetPort: 2456
+  - name: gameport
+    port: {{ .Values.networking.gamePort | int }}
+    targetPort: {{ .Values.networking.gamePort | int }}
     protocol: UDP
-  - name: game2
-    port: 2457
-    targetPort: 2457
+  {{ if .Values.networking.publishQueryPort }}
+  - name: queryport
+    port: {{ .Values.networking.gamePort | int | add 1 }}
+    targetPort: {{ .Values.networking.gamePort | int | add 1 }}
     protocol: UDP
-  - name: game3
-    port: 2458
-    targetPort: 2458
-    protocol: UDP
+  {{ end }}
   type: {{ .Values.networking.serviceType }}
   selector:
     app: valheim-server

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -17,6 +17,10 @@ storage:
 
 networking:
   serviceType: LoadBalancer
+  gamePort: 2456
+  publishQueryPort: "true"
+
+
 
 nodeSelector: {}
 


### PR DESCRIPTION
Adding values to customize the ports the server listens to. Per https://github.com/lloesche/valheim-server-docker/issues/369 only the game port and game port +1 are in use, so the previous game3 port was unneeded. 

Also added relevant docs. 