### PR TITLE
Adding http status check option (take 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ helm install valheim-server valheim-k8s/valheim-k8s  \
 | `storage.pvc.storageClassName`             | The storageClass used to create the persistentVolumeClaim              | `default`               |
 | `storage.pvc.size`                         | The size of the persistent volume to be created                        | `1Gi`                   |
 | `networking.serviceType`                   | The type of service e.g `NodePort`, `LoadBalancer` or `ClusterIP`      | `LoadBalancer`          |
-| `networking.gamePort`                      | The UDP start port the server will listen on                           |  `2456`                 |
-| `networking.publishQueryPort`              | Expose the Steam query port (gamePort + 1)                             |  `true`                 |
+| `networking.gamePort`                      | The UDP start port the server will listen on                           | `2456`                  |
+| `networking.publishQueryPort`              | Expose the Steam query port (gamePort + 1)                             | `true`                  |
+| `networking.statusHttp`                    | Enables the status http server                                         | `false`                 |
 | `nodeSelector`                             |                                                                        | `{}`                    |
 | `image.repository` | Specifies container image repository | `lloesche/valheim-server` |
 | `image.tag` | Specifies container image tag | `latest` |
@@ -72,6 +73,14 @@ Assuming you have taken care of the networking (port-forwarding if needed, LoadB
   * You will be asked for the password in the steam ui and in game
 
 More visual set of instructions [here](https://github.com/mbround18/valheim-docker/discussions/51)
+
+## HTTP Status page
+When your sever is set to public, it serves a status response on UDP game port + 1 (default 2347). The `lloesche/valheim-server` image supports serving this page over http. 
+
+To use this, set `extraEnvironmentVars.SERVER_PUBLIC=true` (default) and `networking.statusHttp=true`.
+
+Note that if you are using a `LoadBalancer` Service type, you must be on Kubernets >= v1.20 and and your LoadBalancer implementation must support it (tested with Metallb and Klipper-lb, [see here for more details](https://github.com/kubernetes/kubernetes/issues/23880)). You must also enable the `MixedProtocolLBService` feature gate by starting your apiserver with the `--feature-gates="MixedProtocolLBService=true"` flag. 
+
 
 ## Potential future updates
 

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -29,6 +29,8 @@ spec:
           value: {{ .Values.password }}
         - name: SERVER_PORT
           value: {{ .Values.networking.gamePort | quote }}
+        - name: STATUS_HTTP
+          value: {{ .Values.networking.statusHttp | quote }}
         {{ if .Values.extraEnvironmentVars -}}
         {{ range $key, $value := .Values.extraEnvironmentVars }}
         - name: {{ $key }}
@@ -40,6 +42,10 @@ spec:
           name: gameport
         - containerPort: {{ .Values.networking.gamePort | int | add 1 }}
           name: queryport
+        {{ if .Values.networking.statusHttp }}
+        - containerPort: 80
+          name: http
+        {{ end }}
         volumeMounts:
         {{ if .Values.storage.kind }}
         - mountPath: /config

--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -14,6 +14,11 @@ spec:
     targetPort: {{ .Values.networking.gamePort | int | add 1 }}
     protocol: UDP
   {{ end }}
+  {{ if .Values.networking.statusHttp }}
+  - name: http
+    port: 80
+    targetPort: 80
+  {{ end }}
   type: {{ .Values.networking.serviceType }}
   selector:
     app: valheim-server

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -19,6 +19,7 @@ networking:
   serviceType: LoadBalancer
   gamePort: 2456
   publishQueryPort: "true"
+  statusHttp: "false"
 
 
 


### PR DESCRIPTION
Adds option to open http status port and start http status server. Builds on #30

Could start working on #23