### PR TITLE
added second volume to Valheim pod to persist server installation on pod recreation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ helm install valheim-server valheim-k8s/valheim-k8s  \
 | `serverStorage.pvc.size`                   | The size of the persistent volume to be created                        | `5Gi`                   |
 | `networking.serviceType`                   | The type of service e.g `NodePort`, `LoadBalancer` or `ClusterIP`      | `LoadBalancer`          |
 | `networking.gamePort`                      | The UDP start port the server will listen on                           |  `2456`                 |
+| `networking.nodePort`                      | When service type is `NodePort`, assign a fixed UDP port to the server |  `""`                   |
 | `networking.publishQueryPort`              | Expose the Steam query port (gamePort + 1)                             |  `true`                 |
 | `nodeSelector`                             |                                                                        | `{}`                    |
 | `image.repository` | Specifies container image repository | `lloesche/valheim-server` |

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ helm install valheim-server valheim-k8s/valheim-k8s  \
 | `storage.hostvol.path`                     | The folder to be mounted into /config in the game-server pod           | `/data/valheim`         |
 | `storage.pvc.storageClassName`             | The storageClass used to create the persistentVolumeClaim              | `default`               |
 | `storage.pvc.size`                         | The size of the persistent volume to be created                        | `1Gi`                   |
+| `serverStorage.kind`                       | Storage strategy/soln used to save the server installation files       | `hostvol`               |
+| `serverStorage.hostvol.path`               | The folder to be mounted into /opt/valheim in the game-server pod      | `/data/valheim-server`  |
+| `serverStorage.pvc.storageClassName`       | The storageClass used to create the persistentVolumeClaim              | `default`               |
+| `serverStorage.pvc.size`                   | The size of the persistent volume to be created                        | `5Gi`                   |
 | `networking.serviceType`                   | The type of service e.g `NodePort`, `LoadBalancer` or `ClusterIP`      | `LoadBalancer`          |
 | `networking.gamePort`                      | The UDP start port the server will listen on                           |  `2456`                 |
 | `networking.publishQueryPort`              | Expose the Steam query port (gamePort + 1)                             |  `true`                 |
@@ -37,7 +41,9 @@ helm install valheim-server valheim-k8s/valheim-k8s  \
 
 ## Persistence
 
-Currently persistence is supported through mounting a `hostvol` or via a `persistentVolumeClaim`. Please create an issue if you would like support for specific cloud storage solutions via PVCs / storageclasses. They vary by provider so PRs / testers welcome for this. 
+Currently persistence is supported through mounting a `hostvol` or via a `persistentVolumeClaim`. Please create an issue if you would like support for specific cloud storage solutions via PVCs / storageclasses. They vary by provider so PRs / testers welcome for this.
+
+You can enable persistence for both the server data (your worlds, mounted at `/config` and configured with the `storage` parameter) and the server installation (to skip downloading it every time a pod is created, mounted at `/opt/valheim`, configured with the `serverStorage` parameter).
 
 ### Using a Host Volume
 

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -45,6 +45,10 @@ spec:
         - mountPath: /config
           name: gamefiles
         {{ end }}
+        {{ if .Values.serverStorage.kind }}
+        - mountPath: /opt/valheim
+          name: serverfiles
+        {{ end }}
         {{ range .Values.extraVolumes }}
         - name: {{ .name }}
           readOnly: true
@@ -58,10 +62,21 @@ spec:
           path: {{ .Values.storage.hostvol.path }}
           type: DirectoryOrCreate
       {{ end }}
+      {{ if eq .Values.serverStorage.kind "hostvol" }}
+      - name: serverfiles
+        hostPath:
+          path: {{ .Values.serverStorage.hostvol.path }}
+          type: DirectoryOrCreate
+      {{ end }}
       {{ if eq .Values.storage.kind "persistentVolumeClaim" }}
       - name: gamefiles
         persistentVolumeClaim:
           claimName: valheim-server-world-data
+      {{ end }}
+      {{ if eq .Values.serverStorage.kind "persistentVolumeClaim" }}
+      - name: serverfiles
+        persistentVolumeClaim:
+          claimName: valheim-server-base-data
       {{ end }}
       {{ range .Values.extraVolumes }}
       - name: {{ .name }}

--- a/chart/templates/persistentvolumeclaim.yml
+++ b/chart/templates/persistentvolumeclaim.yml
@@ -13,3 +13,19 @@ spec:
     requests:
       storage: {{ .Values.storage.pvc.size }}
 {{ end }}
+---
+{{ if eq .Values.serverStorage.kind "persistentVolumeClaim" }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: valheim-server-base-data
+spec:
+  {{ if .Values.serverStorage.pvc.storageClassName }}
+  storageClassName: {{ .Values.serverStorage.pvc.storageClassName }}
+  {{ end }}
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.serverStorage.pvc.size }}
+{{ end }}

--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -8,11 +8,17 @@ spec:
     port: {{ .Values.networking.gamePort | int }}
     targetPort: {{ .Values.networking.gamePort | int }}
     protocol: UDP
+    {{- if eq .Values.networking.serviceType "NodePort" }}
+    nodePort: {{ default "" .Values.networking.nodePort }}
+    {{- end }}
   {{ if .Values.networking.publishQueryPort }}
   - name: queryport
     port: {{ .Values.networking.gamePort | int | add 1 }}
     targetPort: {{ .Values.networking.gamePort | int | add 1 }}
     protocol: UDP
+    {{- if eq .Values.networking.serviceType "NodePort" }}
+    nodePort: {{ default "" (.Values.networking.nodePort | int | add 1) }}
+    {{- end }}
   {{ end }}
   type: {{ .Values.networking.serviceType }}
   selector:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -15,6 +15,13 @@ storage:
   pvc:
     size: 1Gi
 
+serverStorage:
+  kind: hostvol
+  hostvol:
+    path: /data/valheim-server
+  pvc:
+    size: 5Gi
+
 networking:
   serviceType: LoadBalancer
   gamePort: 2456

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -26,7 +26,7 @@ networking:
   serviceType: LoadBalancer
   gamePort: 2456
   publishQueryPort: "true"
-
+  nodePort: 2456
 
 
 nodeSelector: {}


### PR DESCRIPTION
Hi @Addyvan,

I've added a second optional volume to the Valheim deployment so that the server installation files don't have to be downloaded every time a new pod is created.

References for this can be found here: https://github.com/lloesche/valheim-server-docker#basic-docker-usage

To not break any existing deployments, this is a seperate root variable (`serverStorage`) instead of an update to the already existing `storage`.

Cheers,
Florian.