### PR TITLE
Dynamically tag resources and add password from secret support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ helm install valheim-server valheim-k8s/valheim-k8s  \
 | `worldName`                          | Prefix of the world files to use (will make new if missing)            | `example-world-name`      |
 | `serverName`                         | Server name displayed in the server browser(s)                         | `example-server-name`     |
 | `password`                           | Server password                                                        | `password`                |
+| `passwordSecret`                           | Name of Kubernetes secret to pull secret from. Secret should contain a single field labeled `password`                                                        | None                |
 | `storage.kind`                       | Storage strategy/soln used to provide the game-server with persistence | `hostvol`                 |
 | `storage.hostvol.path`               | The folder to be mounted into /config in the game-server pod           | `/data/valheim`           |
 | `storage.pvc.storageClassName`       | The storageClass used to create the persistentVolumeClaim              | `default`                 |

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -42,7 +42,7 @@ spec:
           value: {{ .Values.password }}
         {{ else -}}
         - name: SERVER_PASS
-          value: {{ .Release.Name }}
+          value: "password"
         {{end -}}
         - name: SERVER_PORT
           value: {{ .Values.networking.gamePort | quote }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -1,17 +1,18 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: valheim-server
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
 spec:
   selector:
     matchLabels:
-      app: valheim-server
+      app: {{ .Release.Name }}
   strategy:
     type: Recreate
   template:
     metadata:
       labels:
-        app: valheim-server
+        app: {{ .Release.Name }}
     spec:
       {{- with .Values.nodeSelector }}
       nodeSelector:
@@ -23,14 +24,26 @@ spec:
       {{- end }}
       containers:
       - image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-        name: valheim-server
+        name: {{ .Release.Name }}
         env:
         - name: SERVER_NAME
           value: {{ .Values.serverName }}
         - name: WORLD_NAME
           value: {{ .Values.worldName }}
+        {{ if .Values.passwordSecret -}}
+        - name: SERVER_PASS
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.passwordSecret }}
+              key: password
+              optional: false
+        {{ else if .Values.password -}}
         - name: SERVER_PASS
           value: {{ .Values.password }}
+        {{ else -}}
+        - name: SERVER_PASS
+          value: {{ .Release.Name }}
+        {{end -}}
         - name: SERVER_PORT
           value: {{ .Values.networking.gamePort | quote }}
         {{ if .Values.extraEnvironmentVars -}}
@@ -75,12 +88,12 @@ spec:
       {{ if eq .Values.storage.kind "persistentVolumeClaim" }}
       - name: gamefiles
         persistentVolumeClaim:
-          claimName: valheim-server-world-data
+          claimName: {{ .Release.Name }}-world-data
       {{ end }}
       {{ if eq .Values.serverStorage.kind "persistentVolumeClaim" }}
       - name: serverfiles
         persistentVolumeClaim:
-          claimName: valheim-server-base-data
+          claimName: {{ .Release.Name }}-server-base-data
       {{ end }}
       {{ range .Values.extraVolumes }}
       - name: {{ .name }}

--- a/chart/templates/persistentvolumeclaim.yml
+++ b/chart/templates/persistentvolumeclaim.yml
@@ -2,7 +2,8 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: valheim-server-world-data
+  name: {{ .Release.Name }}-world-data
+  namespace: {{ .Release.Namespace }}
 spec:
   {{ if .Values.storage.pvc.storageClassName }}
   storageClassName: {{ .Values.storage.pvc.storageClassName }}
@@ -18,7 +19,8 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: valheim-server-base-data
+  name: {{ .Release.Name }}-server-base-data
+  namespace: {{ .Release.Namespace }}
 spec:
   {{ if .Values.serverStorage.pvc.storageClassName }}
   storageClassName: {{ .Values.serverStorage.pvc.storageClassName }}

--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -1,7 +1,8 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: valheim-server
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
 spec:
   ports:
   - name: gameport
@@ -22,4 +23,4 @@ spec:
   {{ end }}
   type: {{ .Values.networking.serviceType }}
   selector:
-    app: valheim-server
+    app: {{ .Release.Name }}


### PR DESCRIPTION
Three changes:
1. Set resource names to work off the release name, this is a best practice that makes charts and their resources follow name patterns. 
2. Add support for pulling the password from a secret, as well as a default password if one isn't set in the values. 
3. Set a namespace parameter in resources

Signed-off-by: Dan Garfield <dan@codefresh.io>